### PR TITLE
Handle invalid webhook signatures

### DIFF
--- a/tests/test_github_monitor.py
+++ b/tests/test_github_monitor.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from webhook_monitor import GitHubMonitor
+
+
+def test_verify_signature_invalid_header_returns_false():
+    monitor = GitHubMonitor()
+    monitor.secret = "secret"
+    assert monitor.verify_signature(b"payload", "invalid") is False

--- a/webhook_monitor.py
+++ b/webhook_monitor.py
@@ -97,7 +97,10 @@ class GitHubMonitor:
             return True
         if not signature_header:
             return False
-        sha_name, signature = signature_header.split("=", 1)
+        try:
+            sha_name, signature = signature_header.split("=", 1)
+        except ValueError:
+            return False
         if sha_name != "sha256":
             return False
         mac = hmac.new(self.secret.encode(), msg=payload, digestmod=hashlib.sha256)


### PR DESCRIPTION
## Summary
- avoid ValueError on malformed webhook signature headers
- add regression test for invalid webhook signature

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68986957a9488326a8f227fe0b5244b9